### PR TITLE
Security fix

### DIFF
--- a/TequilaPC/Classes/Fingerprint.cs
+++ b/TequilaPC/Classes/Fingerprint.cs
@@ -50,6 +50,8 @@ public class Fingerprint
     public string FileName { get { return m_FileName; } }
     public string RootPath { get { return m_RootPath; } }
     public string FullName { get { return MyToolkit.ValidPath(Path.Combine(m_RootPath, m_FileName)); } }
+    public string AbsolutePath { get { return Path.GetFullPath(FullName); } }
+    public bool PathIsSafe { get { return MyToolkit.CheckFileName(m_RootPath, m_FileName); } }
     public long Size { get { return m_Size; } }
     public string Checksum { get { return m_Checksum; } }
     public bool Mismatch { get { return m_mismatch; } set { m_mismatch = value; } }

--- a/TequilaPC/Classes/MyToolkit.cs
+++ b/TequilaPC/Classes/MyToolkit.cs
@@ -17,6 +17,20 @@ class MyToolkit
     }
 
     /// <summary>
+    /// Static function to validate against path traversal, i.e. files named "..\bad.txt"
+    /// Returns true if combining the RootPath and FileName results in an absolute path that's inside of the RootPath.
+    /// Returns false if the combined absolute path is not inside of RootPath.
+    /// </summary>
+    /// <param name="RootPath"></param>
+    /// <param name="FileName"></param>
+    /// <returns></returns>
+    public static bool CheckFileName(string RootPath, string FileName) {
+        string combinedPath = Path.Combine(RootPath, FileName);
+        string absolutePath = Path.GetFullPath(combinedPath);
+        return absolutePath.StartsWith(RootPath);
+    }
+
+    /// <summary>
     /// Static function to make sure dashes are appropiate for the specific OS. 
     /// Make sure all paths are absolute, windows paths must contain the drive name at the start for this to work.
     /// </summary>

--- a/TequilaPC/Classes/WorkThread.cs
+++ b/TequilaPC/Classes/WorkThread.cs
@@ -204,7 +204,15 @@ namespace Tequila
                 ProgressEventArgs e = new ProgressEventArgs(i, m_ManifestFileList.Count);
 
                 Fingerprint LocalFingerprint;
-                if (ManifestFingerprint.Size == 0)
+                if (!ManifestFingerprint.PathIsSafe)
+                {
+                    // This manifest entry sets off our path traversal detection!
+                    // 1. Don't attempt to download it, delete it, etc.
+                    // 2. Write a log entry about it.
+                    MyToolkit.ActivityLog("Manifest contains path traversal! File named '" + ManifestFingerprint.FileName + 
+                        "' would be written to '" + ManifestFingerprint.AbsolutePath + "'. Skipping.");
+                }
+                else if (ManifestFingerprint.Size == 0)
                 {
                     // File is to be deleted
                     if (System.IO.File.Exists(ManifestFingerprint.FullName))


### PR DESCRIPTION
This closes the long-standing "evil manifest" issue by detecting any file that would be written/deleted outside of Tequila's root path, using industry-standard Path Traversal detection techniques.

To be clear, path traversal doesn't just mean subdirectories, it's a security term that specifically means files named "..\bad.txt" or "C:\bad.txt".  In my experience testing this patch, Windows 10 does a good job not letting the patcher write/delete to sensitive locations, but it makes sense to confine all file read/writes to the Tequila root folder, and would put a lot of folks' minds at ease.

This PR adds:
- A static function in MyToolKit that validates whether a given file name will land outside of the root path
- Two properties for the FingerPrint class: One to validate that the path is safe, one to provide the absolute path
- A new pre-check in WorkThread.Validate() that refuses to process any manifest entry pointing at a file outside the Tequila root.

Things I'm not sure about:
- The AbsolutePath property might be unnecessary.  Maybe it could just live in the pre-check in WorkThread?
- The pre-check writes to the log when path traversal is detected, but it's silent otherwise. Given that path traversal in a manifest is a likely sign of foul play by the server owner, does it make sense to create a popup warning? We can scan for unsafe paths as soon as the manifest is loaded, should we just not process the manifest at all if it contains unsafe paths?

The manifest I created to test this with is hosted at [https://hbloom1783.neocities.org/manifest.xml](url). It references a very short/harmless text file, [https://hbloom1783.neocities.org/test.txt](url).  I had to add a single line of code to HTTP.cs to enable TLS connection to Neocities. It may be possible to incorporate this into Tequila as well, but it was unrelated to the issue I was trying to fix. That change is as follows:

```
ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
```

I inserted it right before the WebClient.DownloadFileAsync call, and it worked well enough to test this change, but there might be better places to perform this change, or better ways to configure it.